### PR TITLE
Particle-Tracking Integration

### DIFF
--- a/data/convertLinefinderData.ipynb
+++ b/data/convertLinefinderData.ipynb
@@ -1,0 +1,1251 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preprocessing linefinder Data for Display in Firefly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook converts and post-processes data created with [linefinder](https://github.com/zhafen/linefinder) into a format readable by [Firefly](https://github.com/ageller/Firefly)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get started, you will need to install linefinder via\n",
+    "```\n",
+    "pip install linefinder --user\n",
+    "```\n",
+    "Note that, as of writing, linefinder is not yet Python3 enabled... It will be updated soon."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most of the things you, as the user, will change are in the [Parameters](#Parameters) or [Custom Data](#User-Defined-Data,-Classifications,-and-Filters) section, just below the imports."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home1/03057/zhafen/.local/lib/python2.7/site-packages/h5py/__init__.py:34: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
+      "  from ._conv import register_converters as _register_converters\n"
+     ]
+    }
+   ],
+   "source": [
+    "import copy\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import h5py\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from linefinder_FIREreader import FIREreader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import linefinder.analyze_data.worldlines as a_worldlines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import linefinder.utils.presentation_constants as p_constants\n",
+    "import linefinder.utils.file_management as file_management\n",
+    "import linefinder.config as linefinder_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import galaxy_dive.utils.executable_helpers as exec_helpers\n",
+    "import galaxy_dive.analyze_data.particle_data as particle_data\n",
+    "import galaxy_dive.utils.data_operations as data_operations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What simulation to run this for?\n",
+    "sim_name = 'm12i'\n",
+    "\n",
+    "# What snapshot to run this for?\n",
+    "snum = 465"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How do we define our galaxies?\n",
+    "galdef = '_galdefv3'\n",
+    "\n",
+    "# This should usually be the number of snapshots in the simulation\n",
+    "ahf_index = 600"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What Filters to Use\n",
+    "filter_data_keys = [ 'T', 'Z', 'Den', 'is_in_main_gal', 'is_in_other_gal', 'PType' ]\n",
+    "\n",
+    "# These filters should be in log space\n",
+    "log_filters = [ 'T', 'Z', 'Den', ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display parameters\n",
+    "time_data = True # If True, plot worldlines for particles\n",
+    "n_displayed = 100 # Number of worldlines displayed for the time data\n",
+    "\n",
+    "# If True, t=0 is the snapshot at which particles were selected (assumes CGM data)\n",
+    "center_time_on_snapshot = True\n",
+    "\n",
+    "# If True, display a 100x100x100 pkpc ruler with 1 kpc spacing.\n",
+    "include_ruler = True \n",
+    "\n",
+    "# If True, display a circle with radius R_gal aligned parallel to the angular momentum of the stars,\n",
+    "# and a 50 pkpc long line aligned with the angular momentum of the stars (with 1kpc spacing)\n",
+    "include_disk = True\n",
+    "\n",
+    "# If True, add filters that allow us to filter for how long a particle has spent as a\n",
+    "# given classification\n",
+    "time_filters = False\n",
+    "\n",
+    "# If True, display only particles that have left their source 0.5-1 Gyr ago\n",
+    "include_only_recent_data = False\n",
+    "\n",
+    "# If True, only select gas particles\n",
+    "only_select_gas = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save directory\n",
+    "if time_data:\n",
+    "    target_dir = '/home1/03057/zhafen/repos/time-fly/data'\n",
+    "else:\n",
+    "    target_dir = '/home1/03057/zhafen/repos/Latte-CGM/data'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Labels\n",
+    "classification_labels = {\n",
+    "    'is_in_CGM' : 'All',\n",
+    "    'is_CGM_NEP' : 'IGMAcc',\n",
+    "    'is_CGM_IP' : 'Wind',\n",
+    "    'is_CGM_EP' : 'SatWind',\n",
+    "    'is_CGM_satellite' : 'SatISM',\n",
+    "    'is_in_galaxy_halo_interface' : 'Interface',\n",
+    "}\n",
+    "filter_labels = {\n",
+    "    'T' : 'TemperatureK',\n",
+    "    'Z' : 'MetallicitySolar',\n",
+    "    'Den' : 'DensityPerCC',\n",
+    "    'is_in_main_gal' : 'InMainGal',\n",
+    "    'is_in_other_gal' : 'InOtherGal',\n",
+    "    'PType' : 'PType',\n",
+    "    'R' : 'RadiusPkpc',\n",
+    "    'particle_ind' : 'ParticleID',\n",
+    "    'time' : 'TimeGyr',\n",
+    "    'time_as_CGM_NEP' : 'TimeSinceAccGyr',\n",
+    "    'time_as_outside_any_gal_IP' : 'TimeSinceEjectionGyr',\n",
+    "    'time_as_outside_any_gal_EP' : 'TimeSinceEjectionGyr',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User-Defined Data, Classifications, and Filters\n",
+    "A classification is a set of particles you want to show up as a completely different color in Firefly. When `time_data == True` you'll also show `n_displayed` worldlines for particles that are classified as your classification at the specified snapshot `snum`.\n",
+    "\n",
+    "Put your custom classifications below, in the form of boolean arrays where `True` means the particle is part of the classification. The arrays need to be the shape of the particle data, usually `(1e5, 600)`. If you have a classification for a particular particle that's true throughout its entire history, just tile the data.\n",
+    "\n",
+    "A custom filter will allow you to filter the values for a given classification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default the visualization will currently use data from `/scratch/03057/zhafen/linefinder_data` and halo data from `/scratch/03057/zhafen/core`. If you would like to change these permanently you can do so in `linefinder/config.py`. If you used `pip` to install linefinder, then this is probably located in `~/.local/lib/python2.7/site-packages/linefinder`. Otherwise you can overwrite the defaults below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_data_dir = None\n",
+    "custom_halo_data_dir = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add any classifications you would like to this dictionary,\n",
+    "# and they'll be added to the visualization\n",
+    "custom_classifications = {\n",
+    "#     'custom' : np.random.randint( 0, 2, size=(100000, 600) ).astype( bool ),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add any custom filters you would like to this dictionary,\n",
+    "# and they'll be added to the visualization\n",
+    "custom_filters = {\n",
+    "#     'custom' : 10.**np.random.normal( 10., 5., size=(100000, 600) ),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose colors for your custom classifications, in RGB\n",
+    "classification_colors = {\n",
+    "    'custom' : [ 1., 1., 0. ],\n",
+    "}\n",
+    "# Add labels for your classifications and filters. Labels cannot contain spaces or any special\n",
+    "# characters, unfortunately\n",
+    "custom_classification_labels = {\n",
+    "    'custom' : 'Custom',\n",
+    "}\n",
+    "custom_filter_labels = {\n",
+    "    'custom' : 'CustomFilter',\n",
+    "}\n",
+    "\n",
+    "# If you want any of your filters to be in logspace, indicate so here\n",
+    "log_custom_filters = [ 'custom' ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If using the commandline, change the parameters\n",
+    "sim_name, snum = exec_helpers.choose_config_or_commandline(\n",
+    "    [ sim_name, snum ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running for m12i, snapshot 465\n"
+     ]
+    }
+   ],
+   "source": [
+    "print( \"Running for {}, snapshot {}\".format( sim_name, snum ) )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Load the a helper for loading files easily\n",
+    "file_manager = file_management.FileManager( project='CGM_origin' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ind = ahf_index - snum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tag_tail = '_CGM_snum{}'.format( snum )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "defaults, variations = file_manager.get_linefinder_analysis_defaults_and_variations(\n",
+    "    tag_tail,\n",
+    "    sim_names = [ sim_name ],\n",
+    "    galdef = galdef,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sim_name == 'm12i':\n",
+    "    used_args = defaults\n",
+    "else:\n",
+    "    used_args = variations[sim_name]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Custom data dirs, if given.\n",
+    "if custom_data_dir is not None:\n",
+    "    used_args[data_dir] = custom_data_dir\n",
+    "if custom_halo_data_dir is not None:\n",
+    "    used_args[halo_data_dir] = custom_halo_data_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = a_worldlines.Worldlines( **used_args )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "classification_list = p_constants.CLASSIFICATIONS_CGM_ORIGIN\n",
+    "classification_list.append( 'is_in_galaxy_halo_interface' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Include custom classifications\n",
+    "for c_c in custom_classifications.keys():\n",
+    "    \n",
+    "    w.data[c_c] = custom_classifications[c_c]\n",
+    "    \n",
+    "    classification_list.append( c_c )\n",
+    "    \n",
+    "    classification_labels[c_c] = custom_classification_labels[c_c]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Include custom filters\n",
+    "for c_f in custom_filters.keys():\n",
+    "    \n",
+    "    w.data[c_f] = custom_filters[c_f]\n",
+    "    \n",
+    "    filter_data_keys.append( c_f )\n",
+    "    \n",
+    "    filter_labels[c_f] = custom_filter_labels[c_f]\n",
+    "    \n",
+    "    if c_f in log_custom_filters:\n",
+    "        log_filters.append( c_f )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_data( data_key, classification, time_data, seed=None, *args, **kwargs ):\n",
+    "\n",
+    "    if time_data:\n",
+    "        \n",
+    "        if include_only_recent_data and ( classification in time_keys.keys() ):\n",
+    "            optional_masks = [ time_keys[classification], ]\n",
+    "        else:\n",
+    "            optional_masks = []\n",
+    "\n",
+    "        return w.get_masked_data_over_time(\n",
+    "            data_key,\n",
+    "            snum = snum,\n",
+    "            classification = classification,\n",
+    "            n_samples = n_displayed,\n",
+    "            seed = seed,\n",
+    "            optional_masks = optional_masks,\n",
+    "            *args, **kwargs\n",
+    "        ).flatten()\n",
+    "        \n",
+    "    else:\n",
+    "       \n",
+    "        return w.get_masked_data(\n",
+    "            data_key,\n",
+    "            sl = (slice(None),ind),\n",
+    "            classification = classification,\n",
+    "            *args, **kwargs\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mask Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_keys = {\n",
+    "    'is_CGM_NEP' : 'time_as_CGM_NEP',\n",
+    "    'is_CGM_IP' : 'time_as_outside_any_gal_IP',\n",
+    "    'is_CGM_EP' : 'time_as_outside_any_gal_EP',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if include_only_recent_data:\n",
+    "    for classification in classification_list:\n",
+    "        if classification in time_keys.keys():\n",
+    "            w.data_masker.mask_data(\n",
+    "                time_keys[classification],\n",
+    "                0.5,\n",
+    "                1.0,\n",
+    "                optional_mask = True,\n",
+    "                mask_name = time_keys[classification],\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if only_select_gas:\n",
+    "    w.data_masker.mask_data(\n",
+    "        'PType',\n",
+    "        data_value=0,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Retrieval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up random seeds (useful for sampling consistent particles\n",
+    "seeds = {}\n",
+    "for classification in classification_list:\n",
+    "    seeds[classification] = np.random.randint( 1e7 )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home1/03057/zhafen/repos/linefinder/linefinder/analyze_data/worldlines.py:1178: RuntimeWarning: invalid value encountered in less_equal\n",
+      "  is_in_CGM_rvir = ( r_rvir <= config.OUTER_CGM_BOUNDARY ) \\\n",
+      "/home1/03057/zhafen/repos/linefinder/linefinder/analyze_data/worldlines.py:1179: RuntimeWarning: invalid value encountered in greater_equal\n",
+      "  & ( r_rvir >= config.INNER_CGM_BOUNDARY )\n",
+      "/home1/03057/zhafen/repos/linefinder/linefinder/analyze_data/worldlines.py:1188: RuntimeWarning: invalid value encountered in greater\n",
+      "  self.galids.parameters['galaxy_cut']\n",
+      "/home1/03057/zhafen/repos/linefinder/linefinder/analyze_data/worldlines.py:1212: RuntimeWarning: invalid value encountered in less\n",
+      "  ( r_rvir < config.INNER_CGM_BOUNDARY ) |\n",
+      "/home1/03057/zhafen/repos/linefinder/linefinder/analyze_data/worldlines.py:1214: RuntimeWarning: invalid value encountered in less\n",
+      "  self.galids.parameters['galaxy_cut'] )\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Remove classifications where we have no data with that classification\n",
+    "for classification in copy.copy( classification_list ):\n",
+    "    n_class = w.get_data( classification )[:,ind].sum()\n",
+    "    \n",
+    "    if n_class == 0:\n",
+    "        classification_list.remove( classification )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "positions = {}\n",
+    "velocities = {}\n",
+    "\n",
+    "# Get positions and velocities for all classifications we care about\n",
+    "for classification in classification_list:\n",
+    "\n",
+    "    # Get positions and velocities\n",
+    "    class_pos = []\n",
+    "    class_vel = []\n",
+    "        \n",
+    "    for pos_key, vel_key  in zip( [ 'Rx', 'Ry', 'Rz' ], [ 'Vx', 'Vy', 'Vz' ] ):\n",
+    "            ri = get_data(\n",
+    "                pos_key,\n",
+    "                classification = classification,\n",
+    "                time_data = time_data,\n",
+    "                seed = seeds[classification],\n",
+    "            )\n",
+    "            class_pos.append( ri )\n",
+    "\n",
+    "            vi = get_data(\n",
+    "                vel_key,\n",
+    "                classification = classification,\n",
+    "                time_data = time_data,\n",
+    "                seed = seeds[classification],\n",
+    "            )\n",
+    "            class_vel.append( vi )\n",
+    "            \n",
+    "    # Make into a numpy array\n",
+    "    class_pos = np.array( class_pos ).transpose()\n",
+    "    class_vel = np.array( class_vel ).transpose()\n",
+    "    \n",
+    "    # Store the data\n",
+    "    positions[classification] = class_pos\n",
+    "    velocities[classification] = class_vel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# In the case of time data, we also include particle ind\n",
+    "if time_data:\n",
+    "    filter_data_keys.append( 'particle_ind' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter Data\n",
+    "filter_data = {}\n",
+    "for filter_key in filter_data_keys:\n",
+    "    \n",
+    "    filter_data[filter_key] = {}\n",
+    "    \n",
+    "    for classification in classification_list:\n",
+    "\n",
+    "        filter_data[filter_key][classification] = get_data(\n",
+    "            filter_key,\n",
+    "            classification = classification,\n",
+    "            time_data = time_data,\n",
+    "            seed = seeds[classification],\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Include a time array\n",
+    "if time_data:\n",
+    "    filter_key = 'time'\n",
+    "    filter_data[filter_key] = {}\n",
+    "    \n",
+    "    for classification in classification_list:\n",
+    "        \n",
+    "        time_arr = get_data(\n",
+    "            filter_key,\n",
+    "            classification = classification,\n",
+    "            time_data = time_data,\n",
+    "            seed = seeds[classification],\n",
+    "            tile_data = True,\n",
+    "        )\n",
+    "        \n",
+    "        if center_time_on_snapshot:\n",
+    "            time_arr -= w.data['time'][ind]\n",
+    "        \n",
+    "        filter_data[filter_key][classification] = time_arr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if time_filters:    \n",
+    "    for classification in classification_list:\n",
+    "        \n",
+    "        if classification not in time_keys.keys():\n",
+    "            continue\n",
+    "            \n",
+    "        filter_key = time_keys[classification]\n",
+    "        \n",
+    "        time_filter_arr = get_data(\n",
+    "            filter_key,\n",
+    "            classification = classification,\n",
+    "            time_data = time_data,\n",
+    "            seed = seeds[classification],\n",
+    "        )\n",
+    "        \n",
+    "        try:\n",
+    "            filter_data[filter_key][classification] = time_filter_arr\n",
+    "        except KeyError:\n",
+    "            filter_data[filter_key] = {}\n",
+    "            filter_data[filter_key][classification] = time_filter_arr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup a ruler\n",
+    "if include_ruler:\n",
+    "    \n",
+    "    n_ruler_points = 101\n",
+    "    x = np.array([\n",
+    "        np.linspace( 0., 100., n_ruler_points ),\n",
+    "        np.zeros( n_ruler_points ),\n",
+    "        np.zeros( n_ruler_points ),\n",
+    "    ]).transpose()\n",
+    "    \n",
+    "    y = np.roll( x, 1 )\n",
+    "    z = np.roll( x, 2 )\n",
+    "    \n",
+    "    positions['ruler'] = np.concatenate( [ x, y, z ] )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup disk\n",
+    "if include_disk:\n",
+    "    \n",
+    "    # Load data\n",
+    "    s_data = particle_data.ParticleData(\n",
+    "        sdir = file_manager.get_sim_dir( sim_name ),\n",
+    "        snum = snum,\n",
+    "        ptype = linefinder_config.PTYPE_STAR,\n",
+    "        halo_data_dir = file_manager.get_halo_dir( sim_name ),\n",
+    "        main_halo_id = linefinder_config.MAIN_MT_HALO_ID[sim_name],    \n",
+    "    )\n",
+    "    \n",
+    "    # Get length scale\n",
+    "    r_gal = w.r_gal[ind]\n",
+    "\n",
+    "    # Create cicle to rotate\n",
+    "    circle = []\n",
+    "    for phi in np.linspace( 0., 2.*np.pi, 256 ):\n",
+    "\n",
+    "        circle.append(\n",
+    "            [ r_gal*np.cos(phi), r_gal*np.sin(phi), 0. ]\n",
+    "        )\n",
+    "\n",
+    "    circle = np.array( circle )\n",
+    "\n",
+    "    ang_mom_vec = s_data.total_ang_momentum / np.linalg.norm( s_data.total_ang_momentum )\n",
+    "    disk_pos = data_operations.align_axes( circle, ang_mom_vec, align_frame=False )\n",
+    "\n",
+    "    # Get axis pos\n",
+    "    ang_mom_pos = np.tile( ang_mom_vec, (51,1) )\n",
+    "    axis_pos = np.linspace( 0., 50., 51 )[:,np.newaxis]*ang_mom_pos\n",
+    "    \n",
+    "    positions['disk'] = np.concatenate( [ disk_pos, axis_pos ])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and read in the FIRE Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## initialize reader object and choose simulation to run\n",
+    "reader = FIREreader()\n",
+    "reader.directory = file_manager.get_sim_dir( sim_name )\n",
+    "reader.snapnum = snum\n",
+    "## could read this from snapshot times\n",
+    "current_redshift = w.redshift[snum]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## decide which part types to save to JSON\n",
+    "reader.returnParts = [ 'PartType4', ]\n",
+    "\n",
+    "## choose the names the particle types will get in the UI\n",
+    "reader.names = {\n",
+    "    'PartType0':'Gas', \n",
+    "    'PartType1':'HRDM', \n",
+    "    'PartType2':'LRDM', \n",
+    "    'PartType4':'Stars',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add Linefinder categories\n",
+    "for classification in classification_list:\n",
+    "    reader.returnParts.append( classification )\n",
+    "    reader.names[classification] = classification_labels[classification]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add Ruler and Disk\n",
+    "if include_ruler:\n",
+    "    reader.returnParts.append( 'ruler' )\n",
+    "    reader.names['ruler'] = 'ruler'\n",
+    "if include_disk:\n",
+    "    reader.returnParts.append( 'disk' )\n",
+    "    reader.names['disk'] = 'disk'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#define the defaults; this must be run first if you want to change the defaults below\n",
+    "reader.defineDefaults()\n",
+    "\n",
+    "## by what factor should you sub-sample the data (e.g. array[::decimate])\n",
+    "decimate = [ 20, ]\n",
+    "for i in range( len( classification_list) ):\n",
+    "    decimate.append( 1 )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if include_ruler:\n",
+    "    decimate.append( 1 )\n",
+    "if include_disk:\n",
+    "    decimate.append( 1 )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## load in the data from hdf5 files and put it into reader.partsDict\n",
+    "for i,p in enumerate(reader.returnParts):\n",
+    "    reader.decimate[p] = decimate[i]\n",
+    "    reader.returnKeys[p] = []#['Coordinates', 'Density','Velocities','HIIAbundance','Temperature','AgeGyr']\n",
+    "    #Note: you should only try to filter on scalar values (like density).  \n",
+    "    #The magnitude of the Velocities are calculated in Firefly, and you will automatically be allowed to filter on it\n",
+    "    reader.addFilter[p] = []#[False, True, False,True,True,True]\n",
+    "    ## tell it to do the log of density when filtering\n",
+    "    reader.dolog[p] = []#[False, True, False,False,True,False]\n",
+    "    \n",
+    "    \n",
+    "    #NOTE: all dictionaries in the \"options\" reference the swapped names (i.e., reader.names) you define above.  \n",
+    "    #If you don't define reader.names, then you can use the default keys from the hdf5 files \n",
+    "    #(but then you will see those hdf5 names in the Firefly GUI)\n",
+    "    pp = reader.names[p]\n",
+    "    ## set the initial size of the particles when the interface loads\n",
+    "    reader.options['sizeMult'][pp] = 1.\n",
+    " "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Adjust Point Sizes\n",
+    "for classification in classification_list:\n",
+    "    \n",
+    "    pp = classification_labels[classification]\n",
+    "    \n",
+    "    # Adjustments in some cases to allow easier visibility of all categories\n",
+    "    if time_data:\n",
+    "        reader.options['sizeMult'][pp] = 2.5\n",
+    "    else:\n",
+    "#         if classification == 'is_CGM_NEP':\n",
+    "#             reader.options['sizeMult'][pp] = 2.\n",
+    "#         elif classification == 'is_CGM_IP':\n",
+    "#             reader.options['sizeMult'][pp] = 3.\n",
+    "#         elif classification == 'is_in_CGM':\n",
+    "#             reader.options['sizeMult'][pp] = 2.5\n",
+    "#         else:\n",
+    "        reader.options['sizeMult'][pp] = 3.5\n",
+    "            \n",
+    "if include_ruler:\n",
+    "    reader.options['sizeMult']['ruler'] = 4.\n",
+    "if include_disk:\n",
+    "    reader.options['sizeMult']['disk'] = 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the default colors when the interface loads\n",
+    "reader.options['color'] = {\n",
+    "    'Gas':  [1., 0., 0., 1.],\n",
+    "   'HRDM': [1., 1., 0., 0.1],  \n",
+    "   'LRDM': [1., 1., 0., 0.1],  \n",
+    "   'Stars': [ 232./360., 221.21/360., 16.24/360., 0.1],\n",
+    "} \n",
+    "\n",
+    "for classification in classification_list:\n",
+    "    if classification in classification_colors.keys():\n",
+    "        color = classification_colors[classification]\n",
+    "    elif classification is not 'is_in_CGM':\n",
+    "        color = list( p_constants.CLASSIFICATION_COLORS_B[classification] )\n",
+    "    else:\n",
+    "        color = [ 1., 1., 1. ]\n",
+    "    color.append( 1. )\n",
+    "    \n",
+    "    label = classification_labels[classification]\n",
+    "    \n",
+    "    reader.options['color'][label] = color\n",
+    "    \n",
+    "if include_ruler:\n",
+    "    reader.options['color']['ruler'] = [ 1., 1., 1., 1. ]\n",
+    "if include_disk:\n",
+    "    reader.options['color']['disk'] = [ 1., 1., 1., 1. ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'is_CGM_NEP': [], 'is_CGM_satellite': [], 'ruler': [], 'PartType4': ['Coordinates', 'Velocities'], 'is_CGM_EP': [], 'disk': [], 'is_CGM_IP': []}\n",
+      "/scratch/projects/xsede/GalaxiesOnFIRE/core/m12i_res7100/output/snapdir_465/snapshot_465.0.hdf5\n",
+      "This is a cosmological snapshot... converting to physical units\n",
+      "/scratch/projects/xsede/GalaxiesOnFIRE/core/m12i_res7100/output/snapdir_465/snapshot_465.1.hdf5\n",
+      "/scratch/projects/xsede/GalaxiesOnFIRE/core/m12i_res7100/output/snapdir_465/snapshot_465.2.hdf5\n",
+      "/scratch/projects/xsede/GalaxiesOnFIRE/core/m12i_res7100/output/snapdir_465/snapshot_465.3.hdf5\n"
+     ]
+    }
+   ],
+   "source": [
+    "## do stars separately\n",
+    "reader.returnKeys['PartType4']=['Coordinates','Velocities']\n",
+    "reader.addFilter['PartType4']=[False,False]\n",
+    "reader.dolog['PartType4']=[False,False]\n",
+    "\n",
+    "## set the camera center to be at the origin (defaults to np.mean(Coordinates) otherwise)\n",
+    "##     later on we subtract out halo_center from coordinates but could instead make this halo_center\n",
+    "reader.options['center'] = np.array([0., 0., 0.])\n",
+    "\n",
+    "## initialize filter flags and options\n",
+    "reader.defineFilterKeys()\n",
+    "print reader.returnKeys\n",
+    "## load in return keys from snapshot\n",
+    "filenames_opened = reader.populate_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add Linefinder Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Positions and Velocities\n",
+    "for classification in classification_list:\n",
+    "    \n",
+    "    reader.addtodict(\n",
+    "        reader.partsDict,\n",
+    "        None,\n",
+    "        classification,\n",
+    "        'Coordinates',\n",
+    "         sendlog = 0, \n",
+    "         sendmag = 0,\n",
+    "        vals = positions[classification],\n",
+    "        filterFlag = False\n",
+    "    )\n",
+    "    reader.addtodict(\n",
+    "        reader.partsDict,\n",
+    "        None,\n",
+    "        classification,\n",
+    "        'Velocities',\n",
+    "        sendlog = 0, \n",
+    "        sendmag = 0,\n",
+    "        vals = velocities[classification],\n",
+    "        filterFlag = False\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "linefinder_FIREreader.py:409: RuntimeWarning: divide by zero encountered in log10\n",
+      "  vals = np.log10(vals)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Filter by Filter Keys\n",
+    "\n",
+    "for filter_key in filter_data.keys():\n",
+    "    \n",
+    "    specific_filter_data = filter_data[filter_key]\n",
+    "    \n",
+    "    for classification in classification_list:\n",
+    "        \n",
+    "        if classification not in specific_filter_data.keys():\n",
+    "            continue\n",
+    "            \n",
+    "        log_flag = filter_key in log_filters\n",
+    "        \n",
+    "        reader.addtodict(\n",
+    "            reader.partsDict,\n",
+    "            None,\n",
+    "            classification,\n",
+    "            filter_labels[filter_key],\n",
+    "            sendlog = log_flag, \n",
+    "            sendmag = 0,\n",
+    "            vals = specific_filter_data[classification],\n",
+    "            filterFlag = True,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if include_ruler:\n",
+    "    reader.addtodict(\n",
+    "        reader.partsDict,\n",
+    "        None,\n",
+    "        'ruler',\n",
+    "        'Coordinates',\n",
+    "         sendlog = 0, \n",
+    "         sendmag = 0,\n",
+    "        vals = positions['ruler'],\n",
+    "        filterFlag = False\n",
+    "    )\n",
+    "    reader.addtodict(\n",
+    "        reader.partsDict,\n",
+    "        None,\n",
+    "        'ruler',\n",
+    "        'Velocities',\n",
+    "        sendlog = 0, \n",
+    "        sendmag = 0,\n",
+    "        vals = np.zeros( positions['ruler'].shape ),\n",
+    "        filterFlag = False\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if include_disk:\n",
+    "    reader.addtodict(\n",
+    "        reader.partsDict,\n",
+    "        None,\n",
+    "        'disk',\n",
+    "        'Coordinates',\n",
+    "         sendlog = 0, \n",
+    "         sendmag = 0,\n",
+    "        vals = positions['disk'],\n",
+    "        filterFlag = False\n",
+    "    )\n",
+    "    reader.addtodict(\n",
+    "        reader.partsDict,\n",
+    "        None,\n",
+    "        'disk',\n",
+    "        'Velocities',\n",
+    "        sendlog = 0, \n",
+    "        sendmag = 0,\n",
+    "        vals = np.zeros( positions['disk'].shape ),\n",
+    "        filterFlag = False\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Account for Halo Centers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reader.partsDict['PartType4']['Coordinates'] -= w.origin[:,ind]\n",
+    "reader.partsDict['PartType4']['Velocities'] -= w.vel_origin[:,ind]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write the Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "decimating and shuffling ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "## let's shuffle + decimate, add the GUI friendly names\n",
+    "reader.shuffle_dict([ 'PartType4' ]) # Only decimate stars\n",
+    "reader.swap_dict_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('dataDir', '/home1/03057/zhafen/repos/time-fly/data/m12i_CGM_snum465_galdefv3')\n",
+      "writing JSON files ...\n",
+      "REMOVING FILES FROM /home1/03057/zhafen/repos/time-fly/data/m12i_CGM_snum465_galdefv3\n",
+      "SatISM\n",
+      "ruler\n",
+      "IGMAcc\n",
+      "Stars\n",
+      "SatWind\n",
+      "disk\n",
+      "Wind\n",
+      "m12i_CGM_snum465_galdefv3/FIREdataOptions.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Write the json files\n",
+    "reader.dataDir = os.path.join( target_dir, w.tag ) \n",
+    "reader.cleanDataDir = True\n",
+    "reader.createJSON( overwrite=False )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/data/linefinder_FIREreader.py
+++ b/data/linefinder_FIREreader.py
@@ -1,0 +1,627 @@
+import numpy as np
+import pandas as pd
+import copy
+import h5py,os, shutil
+from snapshot_utils import openSnapshot
+
+class FIREreader(object):
+	"""
+	#These are the defaults that can be redefined by the user at runtime.  
+	#These defaults are only applied after running self.defineDefaults().
+
+		#directory that contains all the hdf5 data files
+		self.directory = './' 
+		
+		#snapshot number to open
+		self.snapnum = None
+
+		#particles to return
+		self.returnParts = ['PartType0', 'PartType1', 'PartType2', 'PartType4']
+ 
+		#set names for the particle sets (note: these will be used in the 
+		#   UI of Firefly; 4 characters or less is best)
+		self.names = {'PartType0':'PartType0', 
+					  'PartType1':'PartType1', 
+					  'PartType2':'PartType2', 
+					  'PartType4':'PartType4' }
+		
+		#flag to check if user has already defined the default values
+		self.defined = False
+		
+		#amount to decimate the data before creating the json files 
+		#   (==1 means no decimates, >1 factor by which to reduce the amount of data)
+		self.decimate = dict()
+		
+		#keys from the hd5 file to include in the JSON file for Firefly 
+		#   (must at least include Coordinates)
+		self.returnKeys = dict()
+				
+		#set the weight of the particles (to define the alpha value). 
+		#   This is a function that will calculate the weights
+		self.weightFunction = dict()
+		
+		#set the radii of the particles. This is a function that will 
+		#   calculate the radii
+		self.radiusFunction = dict()
+		
+		#decide whether you want to use the key from returnKeys as 
+		#   a filter item in the UI
+		#NOTE: each of these must be the same length as self.returnKeys
+		self.addFilter = dict()
+  
+		#should we use the log of these values?  
+		#NOTE: this must be the same length as self.returnKeys
+		self.dolog = dict()
+
+		#should we use the magnitude of these values?   
+		#NOTE: this must be the same length as self.returnKeys
+		#NOTE: setting any of these to true will significantly slow down the file creation
+		#NOTE: I calculate magnitude of velocity, if Velocities is 
+		#   supplied, in the web app.  No need to do it here for Velocities.
+		self.domag = dict()
+ 
+		#should we plot using Alex Gurvich's radial profile fit to the 
+		#   SPH particles (==1), or a simple symmetric radial profile?   
+		#NOTE: this must be the same length as self.returnKeys
+		self.doSPHrad = dict()
+		
+		#a dictionary of  for the WebGL app
+		self.options = {'title':'Firefly', #set the title of the webpage
+			########################
+			#these settings are to turn on/off different bits of the user interface
+			'UI':True, #do you want to show the UI?
+			'UIparticle':dict(), #do you want to show the particles 
+			#	in the user interface (default = True). This is a dict 
+			#	with keys of the particle swapnames (as defined in self.names),
+			#	 and is boolean.
+			'UIdropdown':dict(), #do you want to enable the dropdown menus for 
+			#	particles in the user interface (default = True).This is a 
+			#	dict with keys of the particle swapnames (as defined in self.names), 
+			#	and is boolean.
+			'UIcolorPicker':dict(), #do you want to allow the user to change 
+			#	the color (default = True).This is a dict with keys of the 
+			#	particle swapnames (as defined in self.names), and is boolean.
+			'UIfullscreen':True, #do you want to show the fullscreen button?
+			'UIsnapshot':True, #do you want to show the snapshot button?
+			'UIreset':True, #do you want to show the reset button?
+			'UIsavePreset':True, #do you want to show the save preset button?
+			'UIloadNewData':True, #do you want to show the load new data button?
+			'UIcameraControls':True, #do you want to show the camera controls
+			'UIdecimation':True, #do you want to show the decimation slider
+			########################
+			#these settings affect how the data are displayed
+			'center':None, #do you want to define the initial camera center 
+			#	(if not, the WebGL app will calculate the center as the mean 
+			#	of the coordinates of the first particle set loaded in) 
+			#	(should be an np.array of length 3: x,y,z)
+			'camera':None, #initial camera location, NOTE: the magnitude must 
+			#	be >0 (should be an np.array of length 3: x,y,z)
+			'cameraRotation':None, #can set camera rotation if you want 
+			#	(should be an np.array of length 3: xrot, yrot, zrot, in radians)
+			'maxVrange':2000., #maximum range in velocities to use in deciding 
+			#	the length of the velocity vectors (making maxVrange 
+			#	larger will enhance the difference between small and large velocities)
+			'startFly':False, #start in Fly controls? (if False, then 
+			#	start in the default Trackball controls)
+			'friction':None, #set the initial friction for the controls (default is 0.1)
+			'stereo':False, #start in stereo mode?
+			'stereoSep':None, #camera (eye) separation in the stereo 
+			#	mode (default is 0.06, should be < 1)
+			'decimate':None, #set the initial decimation (e.g, 
+			#	you could load in all the data by setting self.decimate to 
+			#	1 above, but only display some fraction by setting 
+			#	self.options.decimate > 1 here).  This is a single value (not a dict)
+			'plotNmax':dict(), #maximum initial number of particles to plot 
+			#	(can be used to decimate on a per particle basis).  This is 
+			#	a dict with keys of the particle swapnames (as defined in self.names)
+			'showVel':dict(), #start by showing the velocity vectors?  
+			#	This is a dict with keys of the particle swapnames 
+			#	(as defined in self.names), and is boolean
+			'velType':dict(), #default type of velocity vectors to plot.  
+			#	This is a dict with keys of the particle swapnames (as defined in self.names), 
+			#	and must be either 'line', 'arrow', or 'triangle'.  (default is 'line')
+			'color':dict(), #set the default color, This is a dict with keys 
+			#	of the particle swapnames (as defined in self.names), must contain 
+			#	4-element lists with rgba. (default is random colors with a = 1)
+			'sizeMult':dict(), #set the default point size multiplier. This is a 
+			#	dict with keys of the particle swapnames (as defined in self.names),
+			#	 default for all sizes is 1.
+			'showParts':dict(), #show particles by default. This is a dict with 
+			#	keys of the particle swapnames (as defined in self.names), 
+			#	boolean, default is true.
+			'filterVals':dict(), #initial filtering selection. This is a dict 
+			#	with initial keys of the particle swapnames (as defined in self.names), 
+			#	then for each filter the [min, max] range 
+			#	(e.g., 'filter':{'Gas':{'log10Density':[0,1],'magVelocities':[20, 100]}} )
+			'filterLims':dict(), #initial [min, max] limits to the filters. 
+			#	This is a dict with initial keys of the particle swapnames 
+			#	(as defined in self.names), then for each filter the [min, max] range 
+			#	(e.g., 'filter':{'Gas':{'log10Density':[0,1],'magVelocities':[20, 100]}} )
+
+			########################
+			#this should not be modified
+			'loaded':True, #used in the web app to check if the options have been read in
+
+		  } 
+		
+		#the prefix of the the JSON files
+		self.JSONfname = 'FIREdata'
+		
+		#write the startup file?
+		self.writeStartup = True
+
+		#remove the data files in the dataDir directory before adding more?
+		self.cleanDataDir = False
+		
+		#set the maximum number of particles per data file
+		self.maxppFile = 1e4
+
+		#in case you want to print the available keys to the screen
+		self.showkeys = False
+		
+		#directory to place all the data files in (assumed to be within the current directory)
+		self.dataDir = None
+
+	"""
+
+
+	def __init__(self, *args,**kwargs):
+##################################################        
+#defaults that can be modified
+
+		#directory that contains all the hdf5 data files
+		self.directory = './' 
+		
+		#snapshot number to open
+		self.snapnum = None
+
+		#particles to return
+		self.returnParts = ['PartType0', 'PartType1', 'PartType2', 'PartType4']
+ 
+		#set names for the particle sets (note: these will be used in the UI of Firefly; 4 characters or less is best)
+		self.names = {'PartType0':'PartType0', 
+					  'PartType1':'PartType1', 
+					  'PartType2':'PartType2', 
+					  'PartType4':'PartType4' }
+		
+		#flag to check if user has already defined the default values
+		self.defined = False
+		
+		#amount to decimate the data before creating the json files (==1 means no decimates, >1 factor by which to reduce the amount of data)
+		self.decimate = dict()
+		
+		#keys from the hd5 file to include in the JSON file for Firefly (must at least include Coordinates)
+		self.returnKeys = dict()
+				
+		#set the weight of the particles (to define the alpha value). This is a function that will calculate the weights
+		self.weightFunction = dict()
+		
+		#set the radii of the particles. This is a function that will calculate the radii
+		self.radiusFunction = dict()
+		
+		#decide whether you want to use the key from returnKeys as a filter item in the UI
+		#NOTE: each of these must be the same length as self.returnKeys
+		self.addFilter = dict()
+  
+		#should we use the log of these values?  
+		#NOTE: this must be the same length as self.returnKeys
+		self.dolog = dict()
+
+		#should we use the magnitude of these values?   
+		#NOTE: this must be the same length as self.returnKeys
+		#NOTE: setting any of these to true will significantly slow down the file creation
+		#NOTE: I calculate magnitude of velocity, if Velocities is supplied, in the web app.  No need to do it here for Velocities.
+		self.domag = dict()
+ 
+		#should we plot using Alex Gurvich's radial profile fit to the SPH particles (==1), or a simple symmetric radial profile?   
+		#NOTE: this must be the same length as self.returnKeys
+		self.doSPHrad = dict()
+		
+		#a dictionary of  for the WebGL app
+		self.options = {'title':'Firefly', #set the title of the webpage
+			########################
+			#these settings are to turn on/off different bits of the user interface
+			'UI':True, #do you want to show the UI?
+			'UIparticle':dict(), #do you want to show the particles 
+			#	in the user interface (default = True). This is a dict 
+			#	with keys of the particle swapnames (as defined in self.names),
+			#	 and is boolean.
+			'UIdropdown':dict(), #do you want to enable the dropdown menus for 
+			#	particles in the user interface (default = True).This is a 
+			#	dict with keys of the particle swapnames (as defined in self.names), 
+			#	and is boolean.
+			'UIcolorPicker':dict(), #do you want to allow the user to change 
+			#	the color (default = True).This is a dict with keys of the 
+			#	particle swapnames (as defined in self.names), and is boolean.
+			'UIfullscreen':True, #do you want to show the fullscreen button?
+			'UIsnapshot':True, #do you want to show the snapshot button?
+			'UIreset':True, #do you want to show the reset button?
+			'UIsavePreset':True, #do you want to show the save preset button?
+			'UIloadNewData':True, #do you want to show the load new data button?
+			'UIcameraControls':True, #do you want to show the camera controls
+			'UIdecimation':True, #do you want to show the decimation slider
+			########################
+			#these settings affect how the data are displayed
+			'center':None, #do you want to define the initial camera center 
+			#	(if not, the WebGL app will calculate the center as the mean 
+			#	of the coordinates of the first particle set loaded in) 
+			#	(should be an np.array of length 3: x,y,z)
+			'camera':None, #initial camera location, NOTE: the magnitude must 
+			#	be >0 (should be an np.array of length 3: x,y,z)
+			'cameraRotation':None, #can set camera rotation if you want 
+			#	(should be an np.array of length 3: xrot, yrot, zrot, in radians)
+			'maxVrange':2000., #maximum range in velocities to use in deciding 
+			#	the length of the velocity vectors (making maxVrange 
+			#	larger will enhance the difference between small and large velocities)
+			'startFly':False, #start in Fly controls? (if False, then 
+			#	start in the default Trackball controls)
+			'friction':None, #set the initial friction for the controls (default is 0.1)
+			'stereo':False, #start in stereo mode?
+			'stereoSep':None, #camera (eye) separation in the stereo 
+			#	mode (default is 0.06, should be < 1)
+			'decimate':None, #set the initial decimation (e.g, 
+			#	you could load in all the data by setting self.decimate to 
+			#	1 above, but only display some fraction by setting 
+			#	self.options.decimate > 1 here).  This is a single value (not a dict)
+			'plotNmax':dict(), #maximum initial number of particles to plot 
+			#	(can be used to decimate on a per particle basis).  This is 
+			#	a dict with keys of the particle swapnames (as defined in self.names)
+			'showVel':dict(), #start by showing the velocity vectors?  
+			#	This is a dict with keys of the particle swapnames 
+			#	(as defined in self.names), and is boolean
+			'velType':dict(), #default type of velocity vectors to plot.  
+			#	This is a dict with keys of the particle swapnames (as defined in self.names), 
+			#	and must be either 'line', 'arrow', or 'triangle'.  (default is 'line')
+			'color':dict(), #set the default color, This is a dict with keys 
+			#	of the particle swapnames (as defined in self.names), must contain 
+			#	4-element lists with rgba. (default is random colors with a = 1)
+			'sizeMult':dict(), #set the default point size multiplier. This is a 
+			#	dict with keys of the particle swapnames (as defined in self.names),
+			#	 default for all sizes is 1.
+			'showParts':dict(), #show particles by default. This is a dict with 
+			#	keys of the particle swapnames (as defined in self.names), 
+			#	boolean, default is true.
+			'filterVals':dict(), #initial filtering selection. This is a dict 
+			#	with initial keys of the particle swapnames (as defined in self.names), 
+			#	then for each filter the [min, max] range 
+			#	(e.g., 'filter':{'Gas':{'log10Density':[0,1],'magVelocities':[20, 100]}} )
+			'filterLims':dict(), #initial [min, max] limits to the filters. 
+			#	This is a dict with initial keys of the particle swapnames 
+			#	(as defined in self.names), then for each filter the [min, max] range 
+			#	(e.g., 'filter':{'Gas':{'log10Density':[0,1],'magVelocities':[20, 100]}} )
+
+			########################
+			#this should not be modified
+			'loaded':True, #used in the web app to check if the options have been read in
+
+		} 
+		
+		#the prefix of the the JSON files
+		self.JSONfname = 'FIREdata'
+		
+		#write the startup file?
+		self.writeStartup = True
+
+		#remove the data files in the dataDir directory before adding more?
+		self.cleanDataDir = False
+		
+		#set the maximum number of particles per data file
+		self.maxppFile = 1e4
+
+		#in case you want to print the available keys to the screen
+		self.showkeys = False
+		
+		#directory to place all the data files in (assumed to be within the current directory)
+		self.dataDir = None
+		
+
+################################################## 
+#don't modify these
+
+		#the data for the JSON file
+		self.partsDict = dict()
+		
+		#keys that shouldn't be shuffled or decimated
+		self.nodecimate = ['filterKeys','doSPHrad']
+		
+		#keys for filtering (will be defined below)
+		self.filterKeys = {}
+		
+		#will store all the file names that are produced (will be defined below in defineFilenames)
+		self.filenames = dict()
+
+		#will contain a list of the files in the order they are read
+		self.loadedHDF5Files = []
+
+
+		self.slash = '/'
+		if os.name == 'nt':
+			self.slash = '\\'
+
+		
+
+################################################## 
+################################################## 
+################################################## 
+		
+	def defineDefaults(self):
+		self.defined = True
+		for p in self.returnParts:
+			#amount to decimate the data (==1 means no decimates, 
+			#   >1 factor by which to reduce the amount of data)
+			self.decimate[p] = 1.
+
+			#keys from the hdf5 file to include in the JSON file for 
+			#   Firefly (must at least include Coordinates)
+			self.returnKeys[p] = ['Coordinates']      
+
+			#set the weight of the particles (to define the alpha value). 
+			#   This is a function that will calculate the weights
+			self.weightFunction[p] = None
+
+			#set the radii of the particles. This is a function that will calculate the radii
+			self.radiusFunction[p] = None
+
+			#decide whether you want to use the key from returnKeys as a filter item in the UI
+			self.addFilter[p] = [False]   
+
+			#should we use the log of these values?  
+			self.dolog[p] = [False]
+
+			#should we use the magnitude of these values?   
+			self.domag[p] = [False]
+
+			#should we plot using Alex Gurvich's radial profile fit to the 
+			#   SPH particles (==1), or a simple symmetric radial profile?   
+			self.doSPHrad[p] = [0]
+
+			#options
+			#dropdown menus
+			pp = self.swapnames(p) 
+			self.options['UIparticle'][pp] = True
+			self.options['UIdropdown'][pp] = True
+			self.options['UIcolorPicker'][pp] = True
+			self.options['color'][pp] = [
+				np.random.random(), 
+				np.random.random(), 
+				np.random.random(), 1.] #set the default color = rgba.  
+			self.options['sizeMult'][pp] = 1. #set the default point size multiplier 
+			self.options['showParts'][pp] = True
+			
+	#used self.names to swap the dictionary keys
+	def swapnames(self, pin):
+		return self.names[pin]
+
+	#adds an array to the dict for a given particle set and data file 
+	def addtodict(self, d, snap, part, dkey, sendlog, sendmag, usekey = None, mfac = 1., vals = None, filterFlag = False):
+		if (usekey is None):
+			ukey = dkey
+		else:
+			ukey = usekey
+		
+		if (vals is None):
+			vals = snap[part + '/' + dkey][...] * mfac
+		else:
+			self.returnKeys[part].append(ukey)
+
+		if (sendlog):
+			ukey = "log10"+ukey
+			vals = np.log10(vals)
+		if (sendmag):  
+			#print "calculating magnitude for ", ukey
+			ukey = "mag"+ukey
+			vals = [np.linalg.norm(v) for v in vals]
+		 
+		if ukey in list(d[part].keys()):
+			d[part][ukey] = np.append(d[part][ukey], vals,  axis=0)
+		else:
+			d[part][ukey] = vals
+
+		if (filterFlag):
+			if ('filterKeys') not in d[part]:
+				d[part]['filterKeys'] = []
+			d[part]['filterKeys'].append(ukey)
+
+	#populate the dict
+	def populate_dict(self):
+		## fill the parts dict with values
+		for ptype in self.returnParts:
+			self.partsDict[ptype]={}
+			if len(self.returnKeys[ptype]) == 0:
+				continue
+			snapdict = openSnapshot(
+				self.directory,
+				self.snapnum,
+				int(ptype[-1]),## PartType%d <-- final character is number
+				keys_to_extract = copy.copy(self.returnKeys[ptype]),
+				header_only=0)
+			for i,key in enumerate(self.returnKeys[ptype]):
+				try:
+					
+					snapvals = snapdict[key]
+					if self.dolog[ptype][i]:
+						snapvals=np.log10(snapvals)
+						key = 'log10%s'%key
+					self.partsDict[ptype][key]=snapvals
+				except KeyError:
+					print("%s has no %s"%(ptype,key))
+
+
+		## return the ordering of the files, so we can reopen them outside of the reader
+		##  if we want...
+		try:
+			self.loadedHDF5Files = snapdict['fnames']
+		except NameError:
+			pass
+		#and on some of the options here
+		for p in list(self.partsDict.keys()):
+			self.partsDict[p]['filterKeys'] = self.filterKeys[p]
+			self.partsDict[p]['doSPHrad'] = self.doSPHrad[p]
+		return self.loadedHDF5Files
+
+	def shuffle_dict( self, keys='all' ):
+		#should we decimate the data? (NOTE: even if decimate = 1, it is wise to shuffle the data so it doesn't display in blocks)
+
+                if keys == 'all':
+                        keys = list( self.partsDict.keys() )
+
+		for p in keys:
+	
+			if (self.decimate[p] > 0): 
+				if (self.decimate[p] > 1):
+					print("decimating and shuffling ...")
+				else:
+					print("shuffling ... ")
+				N = int(len(self.partsDict[p][self.returnKeys[p][0]]))
+				indices = np.arange(N )
+				dindices = np.random.choice(indices, size = int(round(N/self.decimate[p])), replace=False)
+				for k in list(self.partsDict[p].keys()):
+					if (k not in self.nodecimate):
+						self.partsDict[p][k] = self.partsDict[p][k][dindices]
+
+	def swap_dict_names(self):
+		#swap the names
+		for p in list(self.partsDict.keys()):
+			pp = self.swapnames(p)
+			self.partsDict[pp] = self.partsDict.pop(p)
+			
+	#create the JSON file, and then add the name of the variable (parts) that we want in Firefly
+	def createJSON(self, overwrite=False):
+
+		## NOTE ABG: added here default dataDirectory parsing
+		print("dataDir",self.dataDir)
+		if (self.dataDir == None):
+			self.dataDir = ""#self.slash.join(os.path.realpath(__file__).split(self.slash)[:-1]) 
+			self.dataDir = os.path.join(self.dataDir, "%s_%d"%(self.directory.split(self.slash)[-2],self.snapnum))
+
+		print("writing JSON files ...")
+		if (os.path.exists(self.dataDir) and self.cleanDataDir):
+			print("REMOVING FILES FROM "+self.dataDir)	
+			shutil.rmtree(self.dataDir)
+
+		if (not os.path.exists(self.dataDir)):
+			os.makedirs(self.dataDir)
+
+		self.defineFilenames()
+		for p in self.partsDict:
+			nprinted = 0
+			print(p)
+                        dirname = os.path.dirname( self.dataDir )
+			for i,f in enumerate(self.filenames[p]):
+				#print(f)
+				outDict = dict()
+				foo = 0
+				for k in list(self.partsDict[p].keys()):
+					if (isinstance(self.partsDict[p][k], list) or 
+						type(self.partsDict[p][k]) == np.ndarray):
+						if (len(self.partsDict[p][k]) > nprinted):
+							foo = int(np.floor(float(f[1])))
+							#print("list", k, len(self.partsDict[p][k]), nprinted, foo)
+							outDict[k] = self.partsDict[p][k][int(nprinted):(nprinted + foo)]
+					else:
+						if (i == 0):
+							outDict[k] = self.partsDict[p][k]
+
+				nprinted += foo
+				pd.Series(outDict).to_json( os.path.join( dirname, f[0] ), orient='index')
+		#for the options
+		print(self.filenames['options'][0])
+		self.createOptionsJSON()
+		#the list of files
+		pd.Series(self.filenames).to_json(self.dataDir + self.slash + 'filenames.json', orient='index') 
+		#the startup file
+		if (self.writeStartup):
+                        startupDir = os.path.dirname( self.dataDir )
+                        startupFilename = os.path.join( startupDir, 'startup.json' )
+                        basename = os.path.basename( self.dataDir )
+                        entryName = "data" +self.slash+ basename
+                        if overwrite:
+                                pd.Series({"0":entryName}).to_json(startupFilename, orient='index') 
+                        else:
+                                startup_series = pd.read_json( startupFilename, typ='series' )
+
+                                # Avoid duplicates
+                                if entryName in startup_series.values:
+                                        return
+
+                                # Add new entry
+                                key = str( len( startup_series ) )
+                                new_series = pd.Series({key:entryName})
+                                startup_df = pd.concat( [ startup_series, new_series ] )
+
+                                # Sort
+                                startup_df.sort_values( inplace=True )
+                                startup_df = startup_df.reset_index()[0]
+
+                                # Save
+                                startup_df.to_json( startupFilename, orient='index' )
+
+	def defineFilenames(self):
+		#first create the dict of file names and write that to a JSON file
+                basename = os.path.basename( self.dataDir )
+		for p in self.partsDict:
+			nparts = len(self.partsDict[p]['Coordinates'])
+			nused = 0
+			i = 0
+			while nused < nparts:
+				ninfile = min(self.maxppFile, nparts - nused)
+				nused += ninfile
+				foo = [basename + self.slash + self.JSONfname+p+str(i).zfill(3)+'.json', ninfile]
+				if (i == 0):
+					self.filenames[p] = [foo]
+				else:
+					self.filenames[p].append(foo)
+				i += 1
+			self.filenames[p] = np.array(self.filenames[p])
+
+		#for the options
+		self.filenames['options'] = np.array([basename + self.slash + self.JSONfname+'Options.json',0])
+		
+	def createOptionsJSON(self, file = None):
+		#separated this out incase user wants to only write the options file
+		if (file is None):
+                        dirname = os.path.dirname( self.dataDir )
+			file = os.path.join( dirname, self.filenames['options'][0] )
+		pd.Series(self.options).to_json(file, orient='index') 
+ 
+	
+	def defineFilterKeys(self):
+		for p in self.returnParts:
+			self.filterKeys[p] = []
+			pp = self.swapnames(p) 
+			self.options['filterVals'][pp] = dict()
+			self.options['filterLims'][pp] = dict()
+			j = 0
+
+			if (len(self.addFilter[p]) < len(self.returnKeys[p])):
+				self.addFilter[p] = np.full(len(self.returnKeys[p]), self.addFilter[p][0])
+			if (len(self.dolog[p]) < len(self.returnKeys[p])):
+				self.dolog[p] = np.full(len(self.returnKeys[p]), self.dolog[p][0])
+			if (len(self.domag[p]) < len(self.returnKeys[p])):
+				self.domag[p] = np.full(len(self.returnKeys[p]), self.domag[p][0])
+
+			for i,k in enumerate(self.returnKeys[p]):
+				if (self.addFilter[p][i]):
+					self.filterKeys[p].append(k)
+					if (self.dolog[p][i]):
+						self.filterKeys[p][j] = 'log10' + self.filterKeys[p][j]
+					if self.domag[p][i]:
+						self.filterKeys[p][j] = 'mag' + self.filterKeys[p][j]
+					self.options['filterVals'][pp][self.filterKeys[p][j]] = None
+					self.options['filterLims'][pp][self.filterKeys[p][j]] = None
+					j += 1
+				#init.js will automatically add this to the filters if Velocities are provided in the data
+				if (k == "Velocities"):
+					self.options['filterVals'][pp]['magVelocities'] = None
+					self.options['filterLims'][pp]['magVelocities'] = None
+
+	def run(self):
+		if (not self.defined):
+			self.defineDefaults()
+			
+		self.defineFilterKeys()
+		self.populate_dict()
+		self.shuffle_dict()
+		self.swap_dict_names()
+		self.createJSON()
+		print("done")


### PR DESCRIPTION
Added a notebook for converting particle tracking data into a format readable by Firefly.

This uses a modified version of `FIREreader.py`, `linefinder_FIREreader.py`. Alex modified it to make it able to accept data, and I modified it to allow it to automatically generate a `startup.json` that includes multiple options for the data directory. It should probably be merged with `FIREreader.py` at some point.

This notebook currently requires [linefinder](https://github.com/zhafen/linefinder), data generated by linefinder, and Python 2.7 to use.