### PR TITLE
BLD: set minimal requirement for abg_python, bump Firefly-vis version to 2.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="Firefly-vis",
-    version="2.0.3",
+    version="2.0.4",
     author = 'Alex Gurvich, Aaron Geller',
     author_email = 'agurvich@u.northwestern.edu, ageller@northwestern.edu',
     description="A browser-based particle visualization platform",
@@ -31,7 +31,7 @@ setuptools.setup(
           'flask-socketio',
           'flask',
           'requests',
-          'abg_python'
+          'abg_python>=1.0.2'
       ],
     include_package_data=True,
     scripts=["src/Firefly/bin/Firefly"]


### PR DESCRIPTION
This is in response to #62. I hope that it's acceptable as is.