### PR TITLE
BUG: fix incompatibility with pandas>=2.2

### DIFF
--- a/src/firefly/data_reader/json_utils.py
+++ b/src/firefly/data_reader/json_utils.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import os
+import json
 
 def write_to_json(dictionary,path=None):
     """Simple utility function to write a dictionary to a path as :code:`.json` file.
@@ -25,7 +26,9 @@ def load_from_json(path):
     :return: dictionary
     :rtype: dict
     """
-    if os.path.isfile(path):
-        with open(path,'r') as handle:
-            dictionary=pd.io.json.loads(''.join(handle.readlines()))
+    if not os.path.isfile(path):
+        raise FileNotFoundError(path)
+
+    with open(path,'r') as handle:
+        dictionary = json.load(handle)
     return dictionary


### PR DESCRIPTION
This fixes an incompatibility with pandas 2.2 that is currently affecting yt's CI

xref: https://github.com/pandas-dev/pandas/pull/54581