### PR TITLE
add import guard to import relocated AxisError as of numpy-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ If you use Firefly, please cite our [ApJS paper](https://ui.adsabs.harvard.edu/a
 
 Comprehensive documentation is available [here](https://firefly.rcs.northwestern.edu/docs).
 
-*Note: currently Firefly requires numpy version<2.0.  This may not be the default version of numpy installed via `pip install firefly`.* 
-
 ## Contributors 
 ### Primary Developers
 * Aaron Geller

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="firefly",
-    version="3.3.1",
+    version="3.3.2",
     author = 'Alex Gurvich, Aaron Geller',
-    author_email = 'agurvich@u.northwestern.edu, a-geller@northwestern.edu',
+    author_email = 'alex.b.gurvich@gmail.com, a-geller@northwestern.edu',
     description="A browser-based particle visualization platform",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/firefly/data_reader/reader.py
+++ b/src/firefly/data_reader/reader.py
@@ -7,6 +7,11 @@ import requests
 import numpy as np
 import time
 
+## numpy 1.X
+try: AxisError = np.AxisError
+## numpy 2.X
+except: from numpy.exceptions import AxisError
+
 from .settings import Settings,default_settings
 from .tween import TweenParams
 from .particlegroup import ParticleGroup
@@ -720,11 +725,11 @@ class ArrayReader(Reader):
         :type write_to_disk: bool, optional
         :param loud: flag to print status information to the console, defaults to False
         :type loud: bool, optional
-        :raises np.AxisError: if the coordinate data cannot be interpreted
+        :raises AxisError: if the coordinate data cannot be interpreted
         :raises ValueError: if the number of particle groups does not match the number of
             coordinate arrays
-        :raises np.AxisError: if the field data cannot be interpreted
-        :raises np.AxisError: if the field names cannot be interpreted
+        :raises AxisError: if the field data cannot be interpreted
+        :raises AxisError: if the field names cannot be interpreted
         """
 
         super().__init__(**kwargs)
@@ -740,14 +745,14 @@ class ArrayReader(Reader):
             ## passed a jagged array of different coordinates
             pass
         else:
-            raise np.AxisError("Uninterpretable coordinate array, either pass a single (N,3) array"+ 
+            raise AxisError("Uninterpretable coordinate array, either pass a single (N,3) array"+ 
                 " or a jagged list of 'shape' (M,N_m,3)")
 
         ngroups = len(coordinates)
         npartss = np.array([len(coords) for coords in coordinates])
         
         ## check fields and wrap a single field for a single particle group
-        fielderror = np.AxisError("Uninterpretable field array, either pass a single N array"
+        fielderror = AxisError("Uninterpretable field array, either pass a single N array"
                         " or a jagged list of 'shape' (M,N_fm,N_pm)")
         if fields is not None:
             ## special case and want to allow convenient/inconsistent syntax,
@@ -784,7 +789,7 @@ class ArrayReader(Reader):
             nfieldss = [len(this_fields) for this_fields in fields]
 
         ## check field names and generate them if necessary
-        fieldnameerror = np.AxisError("Uninterpretable field array, either pass a single N array"+
+        fieldnameerror = AxisError("Uninterpretable field array, either pass a single N array"+
             " or a jagged list of 'shape' (M,N_fm,N_pm)")
 
         if field_names is not None: 
@@ -1006,7 +1011,7 @@ class SimpleReader(ArrayReader):
         :param coordinates: existing coordinate array that should be appended to, defaults to None
         :type coordinates: np.ndarray, optional
         :raises TypeError: if :code:`coordinates` is not of type :code:`np.ndarray`
-        :raises np.AxisError: if :code:`coordinates` does not have shape (N,3)
+        :raises AxisError: if :code:`coordinates` does not have shape (N,3)
         :return: coordinates, the opened coordinate array from :code:`fname`
         :rtype: np.ndarray
         """
@@ -1018,7 +1023,7 @@ class SimpleReader(ArrayReader):
             elif type(coordinates)!= np.ndarray:
                 raise TypeError("Existing coordinate array must be of type np.ndarry")
             if np.shape(coordinates)[-1] != 3:
-                raise np.AxisError("Last axis of existing coordinate array must be of size 3")
+                raise AxisError("Last axis of existing coordinate array must be of size 3")
 
             ## open the hdf5 group
             if particle_group is not None:

--- a/src/firefly/data_reader/tween.py
+++ b/src/firefly/data_reader/tween.py
@@ -2,6 +2,11 @@ from __future__ import print_function
 
 import numpy as np
 
+## numpy 1.X
+try: AxisError = np.AxisError
+## numpy 2.X
+except: from numpy.exceptions import AxisError
+
 import os 
 
 from .json_utils import write_to_json
@@ -73,8 +78,8 @@ class TweenParams(object):
                 * [d1,d2,...] multiple durations (corresponding to number of keyframes or
                     raises an error)
         :type duration: float/list of float 
-        :raises np.AxisError: if len of coords is not divisible by 3
-        :raises np.AxisError: if len of durations does not match len of coords
+        :raises AxisError: if len of coords is not divisible by 3
+        :raises AxisError: if len of durations does not match len of coords
         """
 
         try:
@@ -82,7 +87,7 @@ class TweenParams(object):
             ##  convenient input
             coords = np.array(coords).reshape(-1,3)
         except:
-            raise np.AxisError("coords should either be a 2d Nx3 numpy array or"+
+            raise AxisError("coords should either be a 2d Nx3 numpy array or"+
                 "a 3N list/array.")
 
         ## convert duration to a 1d numpy array, however it was passed
@@ -92,7 +97,7 @@ class TweenParams(object):
         ## ensure there is a duration per keyframe transition
         ##  TODO: shouldn't durations be 1 less than coordss?
         if duration.shape[0]!=coords.shape[0]:
-            raise np.AxisError(
+            raise AxisError(
                 "Mismatching coords and duration shape (%d,%d)"%(
                     coords.shape[0],
                     duration.shape[0]))


### PR DESCRIPTION
Add numpy 2.0 support by doing:

```python
import numpy as np
## numpy-1.X
try: AxisError = np.AxisError
## numpy-2.X
except: from numpy.exceptions import AxisError

...

raise AxisError
```